### PR TITLE
fix: make feature cards smaller with emoji/title on same line

### DIFF
--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -115,14 +115,16 @@ export function App() {
 
       {/* Features */}
       <section id="features" className="py-16 max-w-5xl mx-auto px-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mt-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-8">
           {FEATURES.map((f) => (
             <div
               key={f.title}
-              className="p-6 rounded-xl border border-gray-100 bg-gray-50/50 hover:bg-gray-50 transition"
+              className="p-4 rounded-xl border border-gray-100 bg-gray-50/50 hover:bg-gray-50 transition"
             >
-              <span className="text-2xl">{f.emoji}</span>
-              <h3 className="font-semibold text-gray-900 mt-3">{f.title}</h3>
+              <div className="flex items-center gap-2">
+                <span className="text-xl">{f.emoji}</span>
+                <h3 className="font-semibold text-gray-900">{f.title}</h3>
+              </div>
               <p className="text-sm text-gray-500 mt-2">{f.desc}</p>
             </div>
           ))}


### PR DESCRIPTION
Closes #7

## Changes

- Reduced card padding from `p-6` to `p-4` to make cards smaller
- Reduced gap between cards from `gap-6` to `gap-4`
- Wrapped emoji and title in a flex row so they appear on the same line
- Slightly reduced emoji size from `text-2xl` to `text-xl` for better proportion