### PR TITLE
fix: make second feature card larger

### DIFF
--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -116,10 +116,10 @@ export function App() {
       {/* Features */}
       <section id="features" className="py-16 max-w-5xl mx-auto px-6">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-8">
-          {FEATURES.map((f) => (
+          {FEATURES.map((f, i) => (
             <div
               key={f.title}
-              className="p-4 rounded-xl border border-gray-100 bg-gray-50/50 hover:bg-gray-50 transition"
+              className={`${i === 1 ? "p-6" : "p-4"} rounded-xl border border-gray-100 bg-gray-50/50 hover:bg-gray-50 transition`}
             >
               <div className="flex items-center gap-2">
                 <span className="text-xl">{f.emoji}</span>


### PR DESCRIPTION
Closes #10

## Changes

- The 2nd feature card ("Visual Markers") now uses `p-6` padding instead of `p-4`, making it visually larger than the other cards as requested in the annotation.